### PR TITLE
Implement Dockerfile for Python project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 ###############################################
 # BASE IMAGE
 ###############################################
-# TODO: Choose appropriate base image
-# FROM <base-image>:<tag>
+# Choose appropriate base image
+FROM python:3.11-slim
 
 ###############################################
 # WORKING DIRECTORY
@@ -15,22 +15,29 @@ WORKDIR /app
 ###############################################
 # SYSTEM DEPENDENCIES
 ###############################################
-# TODO: Install required system dependencies
-# TODO: Setup basic python environment which is needed for final post-processing and scoring
-# RUN apt-get update && apt-get install -y git <other-required-packages>
+# Install required system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    bash \
+    python3 \
+    python3-pip \
+    python3-setuptools \
+    python-is-python3 \
+    && rm -rf /var/lib/apt/lists/*
 
 ###############################################
 # REPO SETUP
 ###############################################
-# TODO: Clone repository, follow the template below
-RUN git clone <repository-url> .
+# Clone repository using build context
+COPY . /tmp/src
+RUN git clone /tmp/src .
 # RUN git submodule update --init --recursive
 
 # Freeze the repository to a reproducible state.
 # Use one of the two approaches below depending on the task version:
 
 # - If the task version is "latest" or there is no specified version, freeze to the latest commit before a given date:
-# RUN LATEST_COMMIT=$(git rev-list -n 1 --before="2025-03-28" HEAD) && git reset --hard $LATEST_COMMIT
+RUN LATEST_COMMIT=$(git rev-list -n 1 --before="2025-03-22" HEAD) && git reset --hard $LATEST_COMMIT
 
 # - If the task version is NOT "latest" (e.g., a specific commit hash), pin to a specific commit explicitly (use this only when needed):
 # RUN git checkout <commit-sha-or-tag>


### PR DESCRIPTION
## Summary
- choose `python:3.11-slim` as base image
- install required system packages (git, bash, python tools)
- clone repo into `/app` from build context and freeze at the latest commit before 2025‑03‑22

## Testing
- `git rev-list -n 1 --before="2025-03-22" HEAD`